### PR TITLE
deprecate this library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Upcoming changes][unreleased]
 
 ### Support
+- add deprecation message to README
+- add links to systemjs-plugin-dojo and ng2-esri-demo to README
 - add links to Josh Werts' blog post and example app
 
 ## [v1.0.0-beta.0]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # esri-system-js
 Load [ArcGIS API for JavaScript] modules using [SystemJS]
 
+> NOTE: this library has been deprecated in favor of [systemjs-plugin-dojo](https://github.com/beginor/systemjs-plugin-dojo) - which is a [SystemJS](https://github.com/systemjs/systemjs) plugin for loading Dojo modules that works with the ArcGIS API for JavaScript. [ng2-esri-demo](https://github.com/beginor/ng2-esri-demo) shows how to use that plugin to load ArcGIS modules in an Angular application.
+
 Provides a wrapper around [SystemJS]'s `register()` function
 that will first use Dojo's AMD loader to load Esri modules,
 and then register a SystemJS module that will expose them.


### PR DESCRIPTION
TODO after merging this:
- [x] [`npm deprecate`](https://docs.npmjs.com/cli/deprecate)
- [ ] update [using frameworks page](https://developers.arcgis.com/javascript/latest/guide/using-frameworks/index.html)
- [x] close open issues
- [ ] archive this repo if the GH admins will let us
